### PR TITLE
self final clean-up script

### DIFF
--- a/overlay/etc/local.d/headless.start
+++ b/overlay/etc/local.d/headless.start
@@ -61,5 +61,14 @@ rc-service networking start
 cp /etc/ssh/sshd_config /etc/ssh/sshd_config.orig
 __edit_ess
 rc-service sshd restart
-mv /etc/ssh/sshd_config.orig /etc/ssh/sshd_config
 
+cat <<-EOF >> /tmp/_clean-up
+	#!/bin/sh
+	mv /etc/ssh/sshd_config.orig /etc/ssh/sshd_config
+	rc-update del local default
+	rm /etc/local.d/headless.start
+	rm /etc/.default_boot_services 
+	EOF
+
+chmod +x /tmp/_clean-up
+exec /tmp/_clean-up


### PR DESCRIPTION
use a clean-up proxy script in /tmp to do final house keeping and suppress original headless.start file.
This removes the need for step 3.4 in [Alpine wiki page](https://wiki.alpinelinux.org/wiki/Raspberry_Pi_-_Headless_Installation)